### PR TITLE
Add initial Sequelize models setup

### DIFF
--- a/models/DashboardState.js
+++ b/models/DashboardState.js
@@ -1,0 +1,40 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const DashboardState = sequelize.define(
+    "DashboardState",
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      channelId: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: "channel_id",
+        comment: "Discord channel ID",
+      },
+      messageId: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: "message_id",
+        comment: "Discord message ID for the dashboard",
+      },
+    },
+    {
+      tableName: "live_dashboard",
+      timestamps: true,
+      underscored: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ["channel_id"],
+          name: "uq__live_dashboard__channel_id",
+        },
+      ],
+    },
+  );
+
+  return DashboardState;
+};

--- a/models/Link.js
+++ b/models/Link.js
@@ -21,10 +21,8 @@ export default (sequelize, Sequelize) => {
         type: DataTypes.STRING,
         allowNull: false,
         defaultValue: "other",
-        validate: {
-          isIn: [["github", "figma", "docs", "other"]],
-        },
-        comment: "DB will enforce CHECK(kind IN ('github','figma','docs','other')) in migration",
+        validate: { notEmpty: true },
+        comment: "Category for the link (e.g., github, figma, docs etc.)",
       },
       url: {
         type: DataTypes.STRING,

--- a/models/Link.js
+++ b/models/Link.js
@@ -58,6 +58,7 @@ export default (sequelize, Sequelize) => {
     Link.belongsTo(models.Project, {
       foreignKey: "project_id",
       as: "project",
+      onDelete: "CASCADE",
     });
   };
 

--- a/models/Link.js
+++ b/models/Link.js
@@ -1,0 +1,67 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const Link = sequelize.define(
+    "Link",
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      projectId: {
+        type: DataTypes.UUID,
+        field: "project_id",
+        references: {
+          model: "projects",
+          key: "id",
+        },
+      },
+      kind: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: "other",
+        validate: {
+          isIn: [["github", "figma", "docs", "other"]],
+        },
+        comment: "DB will enforce CHECK(kind IN ('github','figma','docs','other')) in migration",
+      },
+      url: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          isUrl: true,
+          notEmpty: true,
+        },
+      },
+      description: {
+        type: DataTypes.TEXT,
+      },
+    },
+    {
+      tableName: "links",
+      timestamps: true,
+      underscored: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ["project_id", "url"],
+          name: "uq__links__project_id_url",
+        },
+        {
+          fields: ["project_id"],
+          name: "ix__links__project_id",
+        },
+      ],
+    },
+  );
+
+  Link.associate = (models) => {
+    Link.belongsTo(models.Project, {
+      foreignKey: "project_id",
+      as: "project",
+    });
+  };
+
+  return Link;
+};

--- a/models/Notification.js
+++ b/models/Notification.js
@@ -43,6 +43,11 @@ export default (sequelize, Sequelize) => {
       },
       title: {
         type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          notEmpty: true,
+          len: [1, 100],
+        },
       },
       type: {
         type: DataTypes.STRING,

--- a/models/Notification.js
+++ b/models/Notification.js
@@ -9,13 +9,13 @@ export default (sequelize, Sequelize) => {
         defaultValue: DataTypes.UUIDV4,
         primaryKey: true,
       },
-      discordUserId: {
-        type: DataTypes.STRING,
+      userId: {
+        type: DataTypes.UUID,
         allowNull: false,
-        field: "discord_user_id",
+        field: "user_id",
         references: {
           model: "users",
-          key: "discord_user_id",
+          key: "id",
         },
       },
       projectId: {
@@ -36,11 +36,10 @@ export default (sequelize, Sequelize) => {
         },
         comment: "Links notification to a session - auto-cancel when session ends",
       },
-      type: {
-        type: DataTypes.STRING,
-        allowNull: false,
-      },
       title: {
+        type: DataTypes.STRING,
+      },
+      type: {
         type: DataTypes.STRING,
         allowNull: false,
         validate: {
@@ -98,7 +97,7 @@ export default (sequelize, Sequelize) => {
       underscored: true,
       indexes: [
         {
-          fields: ["discord_user_id", "send_at"],
+          fields: ["user_id", "send_at"],
           where: { is_active: true, status: ["queued", "scheduled", "error"] },
           name: "ix__notifications__user_sendat__active_pending",
         },
@@ -118,7 +117,7 @@ export default (sequelize, Sequelize) => {
 
   Notification.associate = (models) => {
     Notification.belongsTo(models.User, {
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       as: "user",
       onDelete: "CASCADE",
     });
@@ -133,7 +132,7 @@ export default (sequelize, Sequelize) => {
       foreignKey: "session_id",
       as: "session",
       constraints: false,
-      onDelete: "SET NULL",
+      onDelete: "CASCADE",
     });
   };
 

--- a/models/Notification.js
+++ b/models/Notification.js
@@ -36,6 +36,11 @@ export default (sequelize, Sequelize) => {
         },
         comment: "Links notification to a session - auto-cancel when session ends",
       },
+      channelId: {
+        type: DataTypes.STRING,
+        field: "channel_id",
+        comment: "If set, send notification to a specific channel instead of DM",
+      },
       title: {
         type: DataTypes.STRING,
       },
@@ -55,7 +60,6 @@ export default (sequelize, Sequelize) => {
           ],
         },
       },
-      comment: "DB will enforce CHECK(type IN... in migration",
       message: {
         type: DataTypes.TEXT,
         allowNull: false,
@@ -87,8 +91,6 @@ export default (sequelize, Sequelize) => {
         validate: {
           isIn: [["queued", "scheduled", "locked", "sent", "canceled", "error"]],
         },
-        comment:
-          "DB-enforced via CHECK(status IN ('queued','scheduled','locked','sent','canceled','error')) in migration",
       },
     },
     {
@@ -98,13 +100,7 @@ export default (sequelize, Sequelize) => {
       indexes: [
         {
           fields: ["user_id", "send_at"],
-          where: { is_active: true, status: ["queued", "scheduled", "error"] },
-          name: "ix__notifications__user_sendat__active_pending",
-        },
-        {
-          fields: ["session_id"],
-          where: { is_active: true, status: ["queued", "scheduled", "error"] },
-          name: "ix__notifications__session_id__active_pending",
+          name: "ix__notifications__user_sendat",
         },
         {
           fields: ["schedule_cron"],

--- a/models/Notification.js
+++ b/models/Notification.js
@@ -1,0 +1,141 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const Notification = sequelize.define(
+    "Notification",
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      discordUserId: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: "discord_user_id",
+        references: {
+          model: "users",
+          key: "discord_user_id",
+        },
+      },
+      projectId: {
+        type: DataTypes.UUID,
+        field: "project_id",
+        references: {
+          model: "projects",
+          key: "id",
+        },
+        comment: "Links to project for project-specific notifications (e.g., GitHub PRs)",
+      },
+      sessionId: {
+        type: DataTypes.UUID,
+        field: "session_id",
+        references: {
+          model: "sessions",
+          key: "id",
+        },
+        comment: "Links notification to a session - auto-cancel when session ends",
+      },
+      type: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      title: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          isIn: [
+            [
+              "session_reminder",
+              "idle_warning",
+              "event_reminder",
+              "task_due",
+              "pr_notification",
+              "github_activity",
+            ],
+          ],
+        },
+      },
+      comment: "DB will enforce CHECK(type IN... in migration",
+      message: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+        validate: {
+          notEmpty: true,
+        },
+      },
+      sendAt: {
+        type: DataTypes.DATE,
+        field: "send_at",
+        comment: "NULL = send immediately, future date = scheduled",
+      },
+      scheduleCron: {
+        type: DataTypes.STRING,
+        field: "schedule_cron",
+        comment: "For repeating notifications",
+      },
+      isActive: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+        field: "is_active",
+        comment: "Set to false to pause or cancel this notification without deleting it",
+      },
+      status: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: "queued",
+        validate: {
+          isIn: [["queued", "scheduled", "locked", "sent", "canceled", "error"]],
+        },
+        comment:
+          "DB-enforced via CHECK(status IN ('queued','scheduled','locked','sent','canceled','error')) in migration",
+      },
+    },
+    {
+      tableName: "notifications",
+      timestamps: true,
+      underscored: true,
+      indexes: [
+        {
+          fields: ["discord_user_id", "send_at"],
+          where: { is_active: true, status: ["queued", "scheduled", "error"] },
+          name: "ix__notifications__user_sendat__active_pending",
+        },
+        {
+          fields: ["session_id"],
+          where: { is_active: true, status: ["queued", "scheduled", "error"] },
+          name: "ix__notifications__session_id__active_pending",
+        },
+        {
+          fields: ["schedule_cron"],
+          where: { is_active: true },
+          name: "ix__notifications__cron__active",
+        },
+      ],
+    },
+  );
+
+  Notification.associate = (models) => {
+    Notification.belongsTo(models.User, {
+      foreignKey: "discord_user_id",
+      as: "user",
+      onDelete: "CASCADE",
+    });
+
+    Notification.belongsTo(models.Project, {
+      foreignKey: "project_id",
+      as: "project",
+      constraints: false,
+    });
+
+    Notification.belongsTo(models.Session, {
+      foreignKey: "session_id",
+      as: "session",
+      constraints: false,
+      onDelete: "SET NULL",
+    });
+  };
+
+  return Notification;
+};

--- a/models/Project.js
+++ b/models/Project.js
@@ -27,7 +27,6 @@ export default (sequelize, Sequelize) => {
         validate: {
           isIn: [["active", "paused", "archived"]],
         },
-        comment: "DB-enforced via CHECK(status IN ('active','paused','archived')) in migration",
       },
     },
     {
@@ -52,6 +51,13 @@ export default (sequelize, Sequelize) => {
       as: "members",
     });
 
+    Project.belongsToMany(models.Session, {
+      through: models.SessionProject,
+      foreignKey: "project_id",
+      otherKey: "session_id",
+      as: "sessions",
+    });
+
     Project.hasMany(models.ProjectMember, {
       foreignKey: "project_id",
       as: "projectMembers",
@@ -64,10 +70,10 @@ export default (sequelize, Sequelize) => {
       onDelete: "CASCADE",
     });
 
-    Project.hasMany(models.Session, {
+    Project.hasMany(models.SessionProject, {
       foreignKey: "project_id",
-      as: "sessions",
-      onDelete: "SET NULL",
+      as: "sessionProjects",
+      onDelete: "CASCADE",
     });
 
     Project.hasMany(models.Task, {

--- a/models/Project.js
+++ b/models/Project.js
@@ -69,6 +69,11 @@ export default (sequelize, Sequelize) => {
       as: "sessions",
       onDelete: "SET NULL",
     });
+
+    Project.hasMany(models.Task, {
+      foreignKey: "project_id",
+      as: "tasks",
+    });
   };
 
   return Project;

--- a/models/Project.js
+++ b/models/Project.js
@@ -1,0 +1,75 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const Project = sequelize.define(
+    "Project",
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          notEmpty: true,
+          len: [1, 100],
+        },
+      },
+      description: {
+        type: DataTypes.TEXT,
+      },
+      status: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: "active",
+        validate: {
+          isIn: [["active", "paused", "archived"]],
+        },
+        comment: "DB-enforced via CHECK(status IN ('active','paused','archived')) in migration",
+      },
+    },
+    {
+      tableName: "projects",
+      timestamps: true,
+      underscored: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ["name"],
+          name: "uq__projects__name",
+        },
+      ],
+    },
+  );
+
+  Project.associate = (models) => {
+    Project.belongsToMany(models.User, {
+      through: models.ProjectMember,
+      foreignKey: "project_id",
+      otherKey: "discord_user_id",
+      as: "members",
+    });
+
+    Project.hasMany(models.ProjectMember, {
+      foreignKey: "project_id",
+      as: "projectMembers",
+      onDelete: "CASCADE",
+    });
+
+    Project.hasMany(models.Link, {
+      foreignKey: "project_id",
+      as: "links",
+      onDelete: "CASCADE",
+    });
+
+    Project.hasMany(models.Session, {
+      foreignKey: "project_id",
+      as: "sessions",
+      onDelete: "SET NULL",
+    });
+  };
+
+  return Project;
+};

--- a/models/Project.js
+++ b/models/Project.js
@@ -48,7 +48,7 @@ export default (sequelize, Sequelize) => {
     Project.belongsToMany(models.User, {
       through: models.ProjectMember,
       foreignKey: "project_id",
-      otherKey: "discord_user_id",
+      otherKey: "user_id",
       as: "members",
     });
 

--- a/models/ProjectMember.js
+++ b/models/ProjectMember.js
@@ -18,14 +18,26 @@ export default (sequelize, Sequelize) => {
           key: "id",
         },
       },
-      discordUserId: {
-        type: DataTypes.STRING,
+      userId: {
+        type: DataTypes.UUID,
         allowNull: false,
-        field: "discord_user_id",
+        field: "user_id",
         references: {
           model: "users",
-          key: "discord_user_id",
+          key: "id",
         },
+      },
+      isAdmin: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        field: "is_admin",
+      },
+      canAddLinks: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        field: "can_add_links",
       },
       permissions: {
         type: DataTypes.JSONB,
@@ -46,12 +58,12 @@ export default (sequelize, Sequelize) => {
       indexes: [
         {
           unique: true,
-          fields: ["project_id", "discord_user_id"],
-          name: "uq__project_members__project_id_discord_user_id",
+          fields: ["project_id", "user_id"],
+          name: "uq__project_members__project_id_user_id",
         },
         {
-          fields: ["project_id"],
-          name: "ix__project_members__project_id",
+          fields: ["project_id", "is_admin"],
+          name: "ix__project_members__project_id_is_admin",
         },
       ],
     },
@@ -64,7 +76,7 @@ export default (sequelize, Sequelize) => {
     });
 
     ProjectMember.belongsTo(models.User, {
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       as: "user",
     });
   };

--- a/models/ProjectMember.js
+++ b/models/ProjectMember.js
@@ -1,0 +1,73 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const ProjectMember = sequelize.define(
+    "ProjectMember",
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      projectId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: "project_id",
+        references: {
+          model: "projects",
+          key: "id",
+        },
+      },
+      discordUserId: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: "discord_user_id",
+        references: {
+          model: "users",
+          key: "discord_user_id",
+        },
+      },
+      permissions: {
+        type: DataTypes.JSONB,
+        defaultValue: {},
+        comment: "Additional permissions for the member",
+      },
+      joinedAt: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: false,
+        field: "joined_at",
+      },
+    },
+    {
+      tableName: "project_members",
+      timestamps: false,
+      underscored: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ["project_id", "discord_user_id"],
+          name: "uq__project_members__project_id_discord_user_id",
+        },
+        {
+          fields: ["project_id"],
+          name: "ix__project_members__project_id",
+        },
+      ],
+    },
+  );
+
+  ProjectMember.associate = (models) => {
+    ProjectMember.belongsTo(models.Project, {
+      foreignKey: "project_id",
+      as: "project",
+    });
+
+    ProjectMember.belongsTo(models.User, {
+      foreignKey: "discord_user_id",
+      as: "user",
+    });
+  };
+
+  return ProjectMember;
+};

--- a/models/Session.js
+++ b/models/Session.js
@@ -9,13 +9,13 @@ export default (sequelize, Sequelize) => {
         defaultValue: DataTypes.UUIDV4,
         primaryKey: true,
       },
-      discordUserId: {
-        type: DataTypes.STRING,
+      userId: {
+        type: DataTypes.UUID,
         allowNull: false,
-        field: "discord_user_id",
+        field: "user_id",
         references: {
           model: "users",
-          key: "discord_user_id",
+          key: "id",
         },
       },
       projectId: {
@@ -66,14 +66,13 @@ export default (sequelize, Sequelize) => {
       underscored: true,
       indexes: [
         {
-          //Partial unique (add with Umzug/migration)
           unique: true,
-          fields: ["discord_user_id"],
+          fields: ["user_id"],
           where: { ended_at: null },
-          name: "uq__sessions__discord_user_id__ended_at_null",
+          name: "uq__sessions__user_id__ended_at_null",
         },
         {
-          fields: ["discord_user_id", "started_at"],
+          fields: ["user_id", "started_at"],
           name: "ix__sessions__user_started_at",
         },
       ],
@@ -82,7 +81,7 @@ export default (sequelize, Sequelize) => {
 
   Session.associate = (models) => {
     Session.belongsTo(models.User, {
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       as: "user",
       onDelete: "CASCADE",
     });

--- a/models/Session.js
+++ b/models/Session.js
@@ -18,22 +18,6 @@ export default (sequelize, Sequelize) => {
           key: "id",
         },
       },
-      projectId: {
-        type: DataTypes.UUID,
-        field: "project_id",
-        references: {
-          model: "projects",
-          key: "id",
-        },
-      },
-      taskId: {
-        type: DataTypes.INTEGER,
-        field: "task_id",
-        references: {
-          model: "tasks",
-          key: "id",
-        },
-      },
       activity: {
         type: DataTypes.TEXT,
         comment: "What the user is working on / Status message",
@@ -86,16 +70,30 @@ export default (sequelize, Sequelize) => {
       onDelete: "CASCADE",
     });
 
-    Session.belongsTo(models.Project, {
-      foreignKey: "project_id",
-      as: "project",
-      constraints: false,
+    Session.belongsToMany(models.Project, {
+      through: models.SessionProject,
+      foreignKey: "session_id",
+      otherKey: "project_id",
+      as: "projects",
     });
 
-    Session.belongsTo(models.Task, {
-      foreignKey: "task_id",
-      as: "task",
-      constraints: false,
+    Session.belongsToMany(models.Task, {
+      through: models.SessionTask,
+      foreignKey: "session_id",
+      otherKey: "task_id",
+      as: "tasks",
+    });
+
+    Session.hasMany(models.SessionProject, {
+      foreignKey: "session_id",
+      as: "sessionProjects",
+      onDelete: "CASCADE",
+    });
+
+    Session.hasMany(models.SessionTask, {
+      foreignKey: "session_id",
+      as: "sessionTasks",
+      onDelete: "CASCADE",
     });
 
     Session.hasMany(models.Notification, {

--- a/models/Session.js
+++ b/models/Session.js
@@ -1,0 +1,110 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const Session = sequelize.define(
+    "Session",
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      discordUserId: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: "discord_user_id",
+        references: {
+          model: "users",
+          key: "discord_user_id",
+        },
+      },
+      projectId: {
+        type: DataTypes.UUID,
+        field: "project_id",
+        references: {
+          model: "projects",
+          key: "id",
+        },
+      },
+      taskId: {
+        type: DataTypes.INTEGER,
+        field: "task_id",
+        references: {
+          model: "tasks",
+          key: "id",
+        },
+      },
+      activity: {
+        type: DataTypes.TEXT,
+        comment: "What the user is working on / Status message",
+      },
+      startedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: "started_at",
+        comment: "Set at punch-in",
+      },
+      endedAt: {
+        type: DataTypes.DATE,
+        field: "ended_at",
+        comment: "NULL while active, set at punch-out",
+      },
+      targetDurationMinutes: {
+        type: DataTypes.INTEGER,
+        field: "target_duration_minutes",
+        comment: "User intended session length",
+      },
+      autoEnded: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        field: "auto_ended",
+      },
+    },
+    {
+      tableName: "sessions",
+      timestamps: true,
+      underscored: true,
+      indexes: [
+        {
+          //Partial unique (add with Umzug/migration)
+          unique: true,
+          fields: ["discord_user_id"],
+          where: { ended_at: null },
+          name: "uq__sessions__discord_user_id__ended_at_null",
+        },
+        {
+          fields: ["discord_user_id", "started_at"],
+          name: "ix__sessions__user_started_at",
+        },
+      ],
+    },
+  );
+
+  Session.associate = (models) => {
+    Session.belongsTo(models.User, {
+      foreignKey: "discord_user_id",
+      as: "user",
+      onDelete: "CASCADE",
+    });
+
+    Session.belongsTo(models.Project, {
+      foreignKey: "project_id",
+      as: "project",
+      constraints: false,
+    });
+
+    Session.belongsTo(models.Task, {
+      foreignKey: "task_id",
+      as: "task",
+      constraints: false,
+    });
+
+    Session.hasMany(models.Notification, {
+      foreignKey: "session_id",
+      as: "notifications",
+      onDelete: "CASCADE",
+    });
+  };
+
+  return Session;
+};

--- a/models/SessionProject.js
+++ b/models/SessionProject.js
@@ -1,0 +1,76 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const SessionProject = sequelize.define(
+    "SessionProject",
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      sessionId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: "session_id",
+        references: {
+          model: "sessions",
+          key: "id",
+        },
+      },
+      projectId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: "project_id",
+        references: {
+          model: "projects",
+          key: "id",
+        },
+      },
+      notes: {
+        type: DataTypes.TEXT,
+        comment: "Optional notes about work done on this project during session",
+      },
+    },
+    {
+      tableName: "session_projects",
+      timestamps: true,
+      underscored: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ["session_id", "project_id"],
+          name: "uq__session_projects__session_id_project_id",
+        },
+        {
+          fields: ["project_id"],
+          name: "ix__session_projects__project_id",
+        },
+        {
+          fields: ["session_id"],
+          name: "ix__session_projects__session_id",
+        },
+        {
+          fields: ["project_id", "updated_at"],
+          name: "ix__session_projects__project_recent",
+        },
+      ],
+    },
+  );
+
+  SessionProject.associate = (models) => {
+    SessionProject.belongsTo(models.Session, {
+      foreignKey: "session_id",
+      as: "session",
+      onDelete: "CASCADE",
+    });
+
+    SessionProject.belongsTo(models.Project, {
+      foreignKey: "project_id",
+      as: "project",
+      onDelete: "CASCADE",
+    });
+  };
+
+  return SessionProject;
+};

--- a/models/SessionTask.js
+++ b/models/SessionTask.js
@@ -1,0 +1,78 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const SessionTask = sequelize.define(
+    "SessionTask",
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      sessionId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: "session_id",
+        references: {
+          model: "sessions",
+          key: "id",
+        },
+      },
+      taskId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: "task_id",
+        references: {
+          model: "tasks",
+          key: "id",
+        },
+      },
+      completedDuringSession: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        field: "completed_during_session",
+        comment: "Was this task marked as done during this session?",
+      },
+      notes: {
+        type: DataTypes.TEXT,
+        comment: "Notes about progress or blockers for this task",
+      },
+    },
+    {
+      tableName: "session_tasks",
+      timestamps: true,
+      underscored: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ["session_id", "task_id"],
+          name: "uq__session_tasks__session_id_task_id",
+        },
+        {
+          fields: ["task_id"],
+          name: "ix__session_tasks__task_id",
+        },
+        {
+          fields: ["session_id"],
+          name: "ix__session_tasks__session_id",
+        },
+      ],
+    },
+  );
+
+  SessionTask.associate = (models) => {
+    SessionTask.belongsTo(models.Session, {
+      foreignKey: "session_id",
+      as: "session",
+      onDelete: "CASCADE",
+    });
+
+    SessionTask.belongsTo(models.Task, {
+      foreignKey: "task_id",
+      as: "task",
+      onDelete: "CASCADE",
+    });
+  };
+
+  return SessionTask;
+};

--- a/models/Settings.js
+++ b/models/Settings.js
@@ -1,0 +1,44 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const Settings = sequelize.define(
+    "Settings",
+    {
+      discordUserId: {
+        type: DataTypes.STRING,
+        primaryKey: true,
+        field: "discord_user_id",
+        references: {
+          model: "users",
+          key: "discord_user_id",
+        },
+      },
+      preferences: {
+        type: DataTypes.JSONB,
+        defaultValue: {},
+        comment: "All user preferences (personas, notifications, etc.)",
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+        field: "updated_at",
+      },
+    },
+    {
+      tableName: "settings",
+      timestamps: false,
+      underscored: true,
+    },
+  );
+
+  Settings.associate = (models) => {
+    Settings.belongsTo(models.User, {
+      foreignKey: "discord_user_id",
+      as: "user",
+      onDelete: "CASCADE",
+    });
+  };
+
+  return Settings;
+};

--- a/models/Settings.js
+++ b/models/Settings.js
@@ -4,13 +4,13 @@ export default (sequelize, Sequelize) => {
   const Settings = sequelize.define(
     "Settings",
     {
-      discordUserId: {
+      userId: {
         type: DataTypes.STRING,
         primaryKey: true,
-        field: "discord_user_id",
+        field: "user_id",
         references: {
           model: "users",
-          key: "discord_user_id",
+          key: "id",
         },
       },
       preferences: {
@@ -18,23 +18,17 @@ export default (sequelize, Sequelize) => {
         defaultValue: {},
         comment: "All user preferences (personas, notifications, etc.)",
       },
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        defaultValue: Sequelize.NOW,
-        field: "updated_at",
-      },
     },
     {
       tableName: "settings",
-      timestamps: false,
+      timestamps: true,
       underscored: true,
     },
   );
 
   Settings.associate = (models) => {
     Settings.belongsTo(models.User, {
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       as: "user",
       onDelete: "CASCADE",
     });

--- a/models/Settings.js
+++ b/models/Settings.js
@@ -5,7 +5,7 @@ export default (sequelize, Sequelize) => {
     "Settings",
     {
       userId: {
-        type: DataTypes.STRING,
+        type: DataTypes.UUID,
         primaryKey: true,
         field: "user_id",
         references: {

--- a/models/Task.js
+++ b/models/Task.js
@@ -44,8 +44,6 @@ export default (sequelize, Sequelize) => {
         validate: {
           isIn: [["todo", "in_progress", "done", "archived"]],
         },
-        comment:
-          "DB-enforced via CHECK(status IN ('todo','in_progress','done','archived')) in migration",
       },
       dueAt: {
         type: DataTypes.DATE,
@@ -73,16 +71,26 @@ export default (sequelize, Sequelize) => {
     Task.belongsTo(models.User, {
       foreignKey: "user_id",
       as: "user",
+      onDelete: "CASCADE",
     });
 
     Task.belongsTo(models.Project, {
       foreignKey: "project_id",
       as: "project",
+      onDelete: "CASCADE",
     });
 
-    Task.hasMany(models.Session, {
+    Task.belongsToMany(models.Session, {
+      through: models.SessionTask,
       foreignKey: "task_id",
+      otherKey: "session_id",
       as: "sessions",
+    });
+
+    Task.hasMany(models.SessionTask, {
+      foreignKey: "task_id",
+      as: "sessionTasks",
+      onDelete: "CASCADE",
     });
   };
 

--- a/models/Task.js
+++ b/models/Task.js
@@ -9,13 +9,13 @@ export default (sequelize, Sequelize) => {
         primaryKey: true,
         autoIncrement: true,
       },
-      discordUserId: {
-        type: DataTypes.STRING,
+      userId: {
+        type: DataTypes.UUID,
         allowNull: false,
-        field: "discord_user_id",
+        field: "user_id",
         references: {
           model: "users",
-          key: "discord_user_id",
+          key: "id",
         },
       },
       title: {
@@ -50,7 +50,7 @@ export default (sequelize, Sequelize) => {
       underscored: true,
       indexes: [
         {
-          fields: ["discord_user_id", "status"],
+          fields: ["user_id", "status"],
           name: "ix__tasks__user_status",
         },
       ],
@@ -59,7 +59,7 @@ export default (sequelize, Sequelize) => {
 
   Task.associate = (models) => {
     Task.belongsTo(models.User, {
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       as: "user",
     });
 

--- a/models/Task.js
+++ b/models/Task.js
@@ -1,0 +1,73 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const Task = sequelize.define(
+    "Task",
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      discordUserId: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: "discord_user_id",
+        references: {
+          model: "users",
+          key: "discord_user_id",
+        },
+      },
+      title: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          notEmpty: true,
+          len: [1, 200],
+        },
+      },
+      description: {
+        type: DataTypes.TEXT,
+      },
+      status: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: "todo",
+        validate: {
+          isIn: [["todo", "in_progress", "done", "archived"]],
+        },
+        comment:
+          "DB-enforced via CHECK(status IN ('todo','in_progress','done','archived')) in migration",
+      },
+      dueAt: {
+        type: DataTypes.DATE,
+        field: "due_at",
+      },
+    },
+    {
+      tableName: "tasks",
+      timestamps: true,
+      underscored: true,
+      indexes: [
+        {
+          fields: ["discord_user_id", "status"],
+          name: "ix__tasks__user_status",
+        },
+      ],
+    },
+  );
+
+  Task.associate = (models) => {
+    Task.belongsTo(models.User, {
+      foreignKey: "discord_user_id",
+      as: "user",
+    });
+
+    Task.hasMany(models.Session, {
+      foreignKey: "task_id",
+      as: "sessions",
+    });
+  };
+
+  return Task;
+};

--- a/models/Task.js
+++ b/models/Task.js
@@ -18,6 +18,14 @@ export default (sequelize, Sequelize) => {
           key: "id",
         },
       },
+      projectId: {
+        type: DataTypes.UUID,
+        field: "project_id",
+        references: {
+          model: "projects",
+          key: "id",
+        },
+      },
       title: {
         type: DataTypes.STRING,
         allowNull: false,
@@ -53,6 +61,10 @@ export default (sequelize, Sequelize) => {
           fields: ["user_id", "status"],
           name: "ix__tasks__user_status",
         },
+        {
+          fields: ["project_id", "status"],
+          name: "ix__tasks__project_status",
+        },
       ],
     },
   );
@@ -61,6 +73,11 @@ export default (sequelize, Sequelize) => {
     Task.belongsTo(models.User, {
       foreignKey: "user_id",
       as: "user",
+    });
+
+    Task.belongsTo(models.Project, {
+      foreignKey: "project_id",
+      as: "project",
     });
 
     Task.hasMany(models.Session, {

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,82 @@
+export default (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const User = sequelize.define(
+    "User",
+    {
+      discordUserId: {
+        type: DataTypes.STRING,
+        primaryKey: true,
+        field: "discord_user_id",
+        validate: {
+          notEmpty: true,
+        },
+        comment: "Discord snowflake ID",
+      },
+      githubUsername: {
+        type: DataTypes.STRING,
+        field: "github_username",
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          notEmpty: true,
+        },
+      },
+    },
+    {
+      tableName: "users",
+      timestamps: true,
+      underscored: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ["github_username"],
+          name: "uq__users__github_username",
+        },
+      ],
+    },
+  );
+
+  User.associate = (models) => {
+    User.belongsToMany(models.Project, {
+      through: models.ProjectMember,
+      foreignKey: "discord_user_id",
+      otherKey: "project_id",
+      as: "projects",
+    });
+
+    User.hasOne(models.Settings, {
+      foreignKey: "discord_user_id",
+      as: "settings",
+      onDelete: "CASCADE",
+    });
+
+    User.hasMany(models.ProjectMember, {
+      foreignKey: "discord_user_id",
+      as: "projectMembers",
+      onDelete: "CASCADE",
+    });
+
+    User.hasMany(models.Session, {
+      foreignKey: "discord_user_id",
+      as: "sessions",
+      onDelete: "CASCADE",
+    });
+
+    User.hasMany(models.Task, {
+      foreignKey: "discord_user_id",
+      as: "tasks",
+      onDelete: "CASCADE",
+    });
+
+    User.hasMany(models.Notification, {
+      foreignKey: "discord_user_id",
+      as: "notifications",
+      onDelete: "CASCADE",
+    });
+  };
+
+  return User;
+};

--- a/models/User.js
+++ b/models/User.js
@@ -4,10 +4,15 @@ export default (sequelize, Sequelize) => {
   const User = sequelize.define(
     "User",
     {
-      discordUserId: {
-        type: DataTypes.STRING,
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
         primaryKey: true,
-        field: "discord_user_id",
+      },
+      discordId: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: "discord_id",
         validate: {
           notEmpty: true,
         },
@@ -32,6 +37,11 @@ export default (sequelize, Sequelize) => {
       indexes: [
         {
           unique: true,
+          fields: ["discord_id"],
+          name: "uq__users__discord_id",
+        },
+        {
+          unique: true,
           fields: ["github_username"],
           name: "uq__users__github_username",
         },
@@ -42,37 +52,37 @@ export default (sequelize, Sequelize) => {
   User.associate = (models) => {
     User.belongsToMany(models.Project, {
       through: models.ProjectMember,
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       otherKey: "project_id",
       as: "projects",
     });
 
     User.hasOne(models.Settings, {
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       as: "settings",
       onDelete: "CASCADE",
     });
 
     User.hasMany(models.ProjectMember, {
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       as: "projectMembers",
       onDelete: "CASCADE",
     });
 
     User.hasMany(models.Session, {
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       as: "sessions",
       onDelete: "CASCADE",
     });
 
     User.hasMany(models.Task, {
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       as: "tasks",
       onDelete: "CASCADE",
     });
 
     User.hasMany(models.Notification, {
-      foreignKey: "discord_user_id",
+      foreignKey: "user_id",
       as: "notifications",
       onDelete: "CASCADE",
     });


### PR DESCRIPTION
- Added the initial Sequelize model definitions _(first draft)_.

**NB:** I'm leaning toward using Umzug migrations for all schema creation instead of relying on sync().
If so, the models will serve more as “schema docs” and validation helpers, keeping DB structure handled through migrations.