### PR TITLE
Add ready event listener

### DIFF
--- a/.env .example
+++ b/.env .example
@@ -1,12 +1,19 @@
+# Environment mode
+NODE_ENV=development
+
+# Discord
 token= ""
 statusChannelId= ""
 chatSummaryChannelId= ""
 clientId= ""
 guildId= "" 
 sourceChannelIds= []
+
+# AI / Ollama
 ollamaUrl= "https://juno-ollama.fly.dev"
 ollamaModel= "tinyllama"
 
+# Database
 HOST=localhost
 DATABASE_NAME=juno_time_dev
 ADMIN_USERNAME=admin

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import addEvents from "./utils/addEvents.js";
 import { required } from "./utils/envHelpers.js";
 // import { required, parseIds } from "./utils/envHelpers.js";
 import addJobs from "./utils/addJobs.js";
+import { adminDb } from "./models/index.js";
 
 // ---- Read ENV ----
 const TOKEN = required("token");
@@ -25,10 +26,22 @@ const client = new Client({
 
 client.commands = new Collection();
 
+// ---- Database Initialization (Phase 1: Sync) ----
+console.log("Initializing database...");
+await adminDb.sequelize.authenticate();
+console.log("✓ Database connected.");
+
+if (process.env.NODE_ENV !== "production") {
+  await adminDb.sequelize.sync({ alter: true });
+  console.log("✓ Database synced.");
+}
+
 // Load commands, events & add cron jobs
+console.log("Loading bot components...");
 await addCommands(client);
 await addEvents(client);
 await addJobs(client);
 
 // Log in bot
 await client.login(TOKEN);
+console.log("✓ Bot is online.");

--- a/index.js
+++ b/index.js
@@ -44,4 +44,7 @@ await addJobs(client);
 
 // Log in bot
 await client.login(TOKEN);
-console.log("✓ Bot is online.");
+
+client.once("ready", (readyClient) => {
+  console.log(`Ready! Logged in as ${readyClient.user.tag}`);
+});

--- a/utils/addEvents.js
+++ b/utils/addEvents.js
@@ -6,9 +6,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const addEvents = async (client) => {
-  const eventFiles = fs.readdirSync(path.join(__dirname, "./events"));
+  const eventFiles = fs.readdirSync(path.join(__dirname, "../events"));
   for (const file of eventFiles) {
-    const event = await import(`./events/${file}`);
+    const event = await import(`../events/${file}`);
     const eventModule = event.default ?? event;
     if (!eventModule.name || typeof eventModule.execute !== "function") {
       console.warn(`Skipped event ${file}: missing name/execute`);


### PR DESCRIPTION
**NB**: Branched off #20, so only a couple of small changes here, once that is merged

- Added ready event to log bot login status ( Can be moved to separate event file (`events/ready.js`) later if we want)
- Fixed event file path in addEvents utility _(I'm guessing the event folder will live in the root an not utils folder)_