### PR TITLE
fix: move addJobs call to client ready event

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,11 +40,11 @@ if (process.env.NODE_ENV !== "production") {
 console.log("Loading bot components...");
 await addCommands(client);
 await addEvents(client);
-await addJobs(client);
 
 // Log in bot
 await client.login(TOKEN);
 
 client.once("ready", (readyClient) => {
   console.log(`Ready! Logged in as ${readyClient.user.tag}`);
+  addJobs(client);
 });


### PR DESCRIPTION
Moved ```addJobs```, so background jobs does not start before discord has confirmed the bots connection.