### PR TITLE
Add hasSession middleware

### DIFF
--- a/middleware/hasSession.js
+++ b/middleware/hasSession.js
@@ -1,0 +1,16 @@
+export default async function hasSession(interaction) {
+  const { sessionService } = interaction.services;
+
+  try {
+    const session = await sessionService.getOneActiveByDiscordId(interaction.user.id);
+
+    if (!session) return false;
+
+    interaction.activeSession = session;
+    interaction.dbUser = session.user;
+    return true;
+  } catch (err) {
+    console.error("hasSession error:", err);
+    return false;
+  }
+}


### PR DESCRIPTION
#30  **Creates a reusable middleware function to check if a user has an active session before executing commands that require one (e.g., /punch-out, /set-status etc).**

- Only checks and returns boolean
- Commands/events decide their own error messages and replies/buttons etc based on context
- Attaches both activeSession and dbUser to interaction for downstream use