### PR TITLE
feat: project services setup, hope it all works

### DIFF
--- a/services/ProjectService.js
+++ b/services/ProjectService.js
@@ -1,5 +1,189 @@
 export default class ProjectService {
   constructor(db) {
     this.client = db.sequelize;
+    this.Project = db.Project;
+    this.User = db.User;
+    this.ProjectMember = db.ProjectMember;
+    this.Link = db.Link;
+  }
+
+  // CREATE PROJECT
+  async create({ name, description, status = "active", ownerId }) {
+    const project = await this.Project.create({ name, description, status });
+
+    // auto-assign creator as admin
+    await this.ProjectMember.create({
+      projectId: project.id,
+      userId: ownerId,
+      isAdmin: true,
+      canAddLinks: true,
+    });
+
+    return this.getById(project.id);
+  }
+
+  // READ
+  async getById(id) {
+    return this.Project.findByPk(id, {
+      include: [
+        { model: this.ProjectMember, as: "projectMembers" },
+        { model: this.Link, as: "links" },
+      ],
+    });
+  }
+
+  async listActive() {
+    return this.Project.findAll({
+      where: { status: "active" },
+      include: [{ model: this.ProjectMember, as: "projectMembers" }],
+      order: [["updatedAt", "DESC"]],
+    });
+  }
+
+  async listByUser(userId) {
+    return this.Project.findAll({
+      include: [
+        {
+          model: this.ProjectMember,
+          as: "projectMembers",
+          where: { userId },
+        },
+      ],
+      order: [["updatedAt", "DESC"]],
+    });
+  }
+
+  // UPDATE
+  async update({ id, userId, args }) {
+    const project = await this.Project.findOne({
+      where: { id },
+      include: [{ model: this.ProjectMember, as: "projectMembers" }],
+    });
+    if (!project) throw new Error("Project not found.");
+
+    const member = project.projectMembers.find((m) => m.userId === userId);
+    if (!member) throw new Error("You are not a member of this project.");
+    if (!member.isAdmin && !member.permissions?.canEdit)
+      throw new Error("You don't have permission to edit this project.");
+
+    await this.Project.update(args, { where: { id } });
+    return this.getById(id);
+  }
+
+  // DELETE (soft delete / archive)
+  async archive({ id, userId }) {
+    const project = await this.Project.findOne({
+      where: { id },
+      include: [{ model: this.ProjectMember, as: "projectMembers" }],
+    });
+    if (!project) throw new Error("Project not found.");
+
+    const member = project.projectMembers.find((m) => m.userId === userId);
+    if (!member?.isAdmin) throw new Error("You don't have permission to archive this project.");
+
+    await this.Project.update({ status: "archived" }, { where: { id } });
+    return this.getById(id);
+  }
+
+  async restore({ id, userId }) {
+    const project = await this.Project.findOne({
+      where: { id },
+      include: [{ model: this.ProjectMember, as: "projectMembers" }],
+    });
+    if (!project) throw new Error("Project not found.");
+
+    const member = project.projectMembers.find((m) => m.userId === userId);
+    if (!member?.isAdmin) throw new Error("You don't have permission to restore this project.");
+
+    await this.Project.update({ status: "active" }, { where: { id } });
+    return this.getById(id);
+  }
+
+  // PROJECT MEMBERS
+  async addMember({ projectId, userId, addedBy }) {
+    const project = await this.Project.findOne({
+      where: { id: projectId },
+      include: [{ model: this.ProjectMember, as: "projectMembers" }],
+    });
+    if (!project) throw new Error("Project not found.");
+
+    const member = project.projectMembers.find((m) => m.userId === addedBy);
+    if (!member?.isAdmin) throw new Error("You don't have permission to add members.");
+
+    const existing = project.projectMembers.find((m) => m.userId === userId);
+    if (existing) throw new Error("User is already a member.");
+
+    await this.ProjectMember.create({
+      projectId,
+      userId,
+      isAdmin: false,
+      canAddLinks: false,
+    });
+
+    return this.getById(projectId);
+  }
+
+  async removeMember({ projectId, userId, removedBy }) {
+    const project = await this.Project.findOne({
+      where: { id: projectId },
+      include: [{ model: this.ProjectMember, as: "projectMembers" }],
+    });
+    if (!project) throw new Error("Project not found.");
+
+    const member = project.projectMembers.find((m) => m.userId === removedBy);
+    if (!member?.isAdmin) throw new Error("You don't have permission to remove members.");
+
+    await this.ProjectMember.destroy({ where: { projectId, userId } });
+    return this.getById(projectId);
+  }
+
+  async setPermissions({ projectId, targetId, editorId, perms }) {
+    const project = await this.Project.findOne({
+      where: { id: projectId },
+      include: [{ model: this.ProjectMember, as: "projectMembers" }],
+    });
+    if (!project) throw new Error("Project not found.");
+
+    const editor = project.projectMembers.find((m) => m.userId === editorId);
+    if (!editor?.isAdmin) throw new Error("You don't have permission to edit member roles.");
+
+    const target = project.projectMembers.find((m) => m.userId === targetId);
+    if (!target) throw new Error("User not found in project.");
+
+    await this.ProjectMember.update(perms, {
+      where: { projectId, userId: targetId },
+    });
+
+    return this.getById(projectId);
+  }
+
+  // LINKS
+  async addLink({ projectId, userId, kind, url, description }) {
+    const project = await this.Project.findOne({
+      where: { id: projectId },
+      include: [{ model: this.ProjectMember, as: "projectMembers" }],
+    });
+    if (!project) throw new Error("Project not found.");
+
+    const member = project.projectMembers.find((m) => m.userId === userId);
+    if (!member) throw new Error("You’re not part of this project.");
+    if (!member.isAdmin && !member.canAddLinks)
+      throw new Error("You don’t have permission to add links.");
+
+    return this.Link.create({ projectId, kind, url, description });
+  }
+
+  async removeLink({ projectId, userId, linkId }) {
+    const project = await this.Project.findOne({
+      where: { id: projectId },
+      include: [{ model: this.ProjectMember, as: "projectMembers" }],
+    });
+    if (!project) throw new Error("Project not found.");
+
+    const member = project.projectMembers.find((m) => m.userId === userId);
+    if (!member?.isAdmin) throw new Error("You don’t have permission to remove links.");
+
+    await this.Link.destroy({ where: { id: linkId, projectId } });
+    return this.getById(projectId);
   }
 }

--- a/services/ProjectService.js
+++ b/services/ProjectService.js
@@ -16,17 +16,26 @@ export default class ProjectService {
     if (ownerId === undefined || ownerId === null || ownerId === "") {
       throw new Error("ownerId is required.");
     }
-    const project = await this.Project.create({ name, description, status });
+    return await this.client.transaction(async (t) => {
+      const project = await this.Project.create(
+        { name, description, status },
+        { transaction: t }
+      );
 
-    // auto-assign creator as admin
-    await this.ProjectMember.create({
-      projectId: project.id,
-      userId: ownerId,
-      isAdmin: true,
-      canAddLinks: true,
+      // auto-assign creator as admin
+      await this.ProjectMember.create(
+        {
+          projectId: project.id,
+          userId: ownerId,
+          isAdmin: true,
+          canAddLinks: true,
+        },
+        { transaction: t }
+      );
+
+      // ensure getById uses the transaction for consistency
+      return this.getById(project.id);
     });
-
-    return this.getById(project.id);
   }
 
   // READ

--- a/services/ProjectService.js
+++ b/services/ProjectService.js
@@ -9,17 +9,16 @@ export default class ProjectService {
 
   // CREATE PROJECT
   async create({ name, description, status = "active", ownerId }) {
-    // Validate required parameters
     if (typeof name !== "string" || name.trim() === "") {
       throw new Error("Project name is required and must be a non-empty string.");
     }
-    if (ownerId === undefined || ownerId === null || ownerId === "") {
+    if (!ownerId) {
       throw new Error("ownerId is required.");
     }
-    return await this.client.transaction(async (t) => {
-      const project = await this.Project.create({ name, description, status }, { transaction: t });
 
-      // auto-assign creator as admin
+    return await this.client.transaction(async (transaction) => {
+      const project = await this.Project.create({ name, description, status }, { transaction });
+
       await this.ProjectMember.create(
         {
           projectId: project.id,
@@ -27,21 +26,21 @@ export default class ProjectService {
           isAdmin: true,
           canAddLinks: true,
         },
-        { transaction: t },
+        { transaction },
       );
 
-      // ensure getById uses the transaction for consistency
-      return this.getById(project.id);
+      return this.getById(project.id, { transaction });
     });
   }
 
   // READ
-  async getById(id) {
+  async getById(id, options = {}) {
     return this.Project.findByPk(id, {
       include: [
         { model: this.ProjectMember, as: "projectMembers" },
         { model: this.Link, as: "links" },
       ],
+      ...options,
     });
   }
 
@@ -123,8 +122,7 @@ export default class ProjectService {
     });
     if (!project) throw new Error("Project not found.");
     if (project.status === "active") return project;
-    if (project.status === 'active') return project;
-  
+
     const member = project.projectMembers.find((m) => m.userId === userId);
     if (!member?.isAdmin) throw new Error("You don't have permission to restore this project.");
 

--- a/services/ProjectService.js
+++ b/services/ProjectService.js
@@ -17,10 +17,7 @@ export default class ProjectService {
       throw new Error("ownerId is required.");
     }
     return await this.client.transaction(async (t) => {
-      const project = await this.Project.create(
-        { name, description, status },
-        { transaction: t }
-      );
+      const project = await this.Project.create({ name, description, status }, { transaction: t });
 
       // auto-assign creator as admin
       await this.ProjectMember.create(
@@ -30,7 +27,7 @@ export default class ProjectService {
           isAdmin: true,
           canAddLinks: true,
         },
-        { transaction: t }
+        { transaction: t },
       );
 
       // ensure getById uses the transaction for consistency
@@ -82,8 +79,21 @@ export default class ProjectService {
     if (!member.isAdmin && !member.permissions?.canEdit)
       throw new Error("You don't have permission to edit this project.");
 
-    await this.Project.update(args, { where: { id } });
-    return this.getById(id);
+    // Only allow specific fields to be updated
+    const allowedFields = ["name", "description", "status"];
+    const updateData = {};
+    for (const key of allowedFields) {
+      if (Object.prototype.hasOwnProperty.call(args, key)) {
+        updateData[key] = args[key];
+      }
+    }
+    await this.Project.update(updateData, { where: { id } });
+    return this.Project.findByPk(id, {
+      include: [
+        { model: this.ProjectMember, as: "projectMembers" },
+        { model: this.Link, as: "links" },
+      ],
+    });
   }
 
   // DELETE (soft delete / archive)
@@ -93,12 +103,17 @@ export default class ProjectService {
       include: [{ model: this.ProjectMember, as: "projectMembers" }],
     });
     if (!project) throw new Error("Project not found.");
-
+    if (project.status === "archived") return project;
     const member = project.projectMembers.find((m) => m.userId === userId);
     if (!member?.isAdmin) throw new Error("You don't have permission to archive this project.");
 
     await this.Project.update({ status: "archived" }, { where: { id } });
-    return this.getById(id);
+    return this.Project.findByPk(id, {
+      include: [
+        { model: this.ProjectMember, as: "projectMembers" },
+        { model: this.Link, as: "links" },
+      ],
+    });
   }
 
   async restore({ id, userId }) {
@@ -107,6 +122,7 @@ export default class ProjectService {
       include: [{ model: this.ProjectMember, as: "projectMembers" }],
     });
     if (!project) throw new Error("Project not found.");
+    if (project.status === "active") return project;
 
     const member = project.projectMembers.find((m) => m.userId === userId);
     if (!member?.isAdmin) throw new Error("You don't have permission to restore this project.");
@@ -117,6 +133,8 @@ export default class ProjectService {
 
   // PROJECT MEMBERS
   async addMember({ projectId, userId, addedBy }) {
+    const user = await this.User.findByPk(userId);
+    if (!user) throw new Error("User not found.");
     const project = await this.Project.findOne({
       where: { id: projectId },
       include: [{ model: this.ProjectMember, as: "projectMembers" }],
@@ -148,7 +166,15 @@ export default class ProjectService {
 
     const member = project.projectMembers.find((m) => m.userId === removedBy);
     if (!member?.isAdmin) throw new Error("You don't have permission to remove members.");
-
+    // Prevent removing the last admin
+    const toRemove = project.projectMembers.find((m) => m.userId === userId);
+    if (!toRemove) throw new Error("User not found in project.");
+    if (toRemove.isAdmin) {
+      const adminCount = project.projectMembers.filter((m) => m.isAdmin).length;
+      if (adminCount <= 1) {
+        throw new Error("Cannot remove the last admin from the project.");
+      }
+    }
     await this.ProjectMember.destroy({ where: { projectId, userId } });
     return this.getById(projectId);
   }
@@ -166,7 +192,14 @@ export default class ProjectService {
     const target = project.projectMembers.find((m) => m.userId === targetId);
     if (!target) throw new Error("User not found in project.");
 
-    await this.ProjectMember.update(perms, {
+    const allowedFields = ["isAdmin", "canAddLinks"];
+    const safePerms = {};
+    for (const key of allowedFields) {
+      if (Object.prototype.hasOwnProperty.call(perms, key)) {
+        safePerms[key] = perms[key];
+      }
+    }
+    await this.ProjectMember.update(safePerms, {
       where: { projectId, userId: targetId },
     });
 
@@ -198,6 +231,9 @@ export default class ProjectService {
 
     const member = project.projectMembers.find((m) => m.userId === userId);
     if (!member?.isAdmin) throw new Error("You don’t have permission to remove links.");
+
+    const link = await this.Link.findOne({ where: { id: linkId, projectId } });
+    if (!link) throw new Error("Link not found in this project.");
 
     await this.Link.destroy({ where: { id: linkId, projectId } });
     return this.getById(projectId);

--- a/services/ProjectService.js
+++ b/services/ProjectService.js
@@ -9,6 +9,13 @@ export default class ProjectService {
 
   // CREATE PROJECT
   async create({ name, description, status = "active", ownerId }) {
+    // Validate required parameters
+    if (typeof name !== "string" || name.trim() === "") {
+      throw new Error("Project name is required and must be a non-empty string.");
+    }
+    if (ownerId === undefined || ownerId === null || ownerId === "") {
+      throw new Error("ownerId is required.");
+    }
     const project = await this.Project.create({ name, description, status });
 
     // auto-assign creator as admin

--- a/services/ProjectService.js
+++ b/services/ProjectService.js
@@ -123,7 +123,8 @@ export default class ProjectService {
     });
     if (!project) throw new Error("Project not found.");
     if (project.status === "active") return project;
-
+    if (project.status === 'active') return project;
+  
     const member = project.projectMembers.find((m) => m.userId === userId);
     if (!member?.isAdmin) throw new Error("You don't have permission to restore this project.");
 


### PR DESCRIPTION
- Added a first draft of `ProjectService` covering project creation, updates, archive/restore, member management, and link handling.
- Creator is automatically assigned as an admin on project creation.
- Basic permission checks are in place for all edit/delete functions.

This hasn’t been tested yet, leaving it open for review and feedback while I wiring it up to commands.
I’ll add the add/edit/delete project command handlers next to test them so perhaps wait for that PR to be pushed before this one gets approval.