### PR TITLE
feat(guards): add actionable Clock in/out buttons + handler

### DIFF
--- a/events/guards/handle-guard-buttons.js
+++ b/events/guards/handle-guard-buttons.js
@@ -1,0 +1,71 @@
+import { Events, MessageFlags, time, TimestampStyles } from "discord.js";
+import { formatDurationMs } from "../../utils/formatTime.js";
+
+export default {
+  name: Events.InteractionCreate,
+  async execute(interaction) {
+    if (!interaction.isButton()) return;
+
+    const id = interaction.customId;
+    if (id !== "guard.clock-in" && id !== "guard.clock-out") return;
+
+    const { userService, sessionService } = interaction.services;
+    const user = await userService.getOneDiscordId(interaction.user.id);
+
+    if (!user) {
+      return interaction.reply({
+        content: "You're not in the database yet. Use `/create-user` first.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+
+    await interaction.deferUpdate();
+
+    try {
+      if (id === "guard.clock-in") {
+        const startResult = await sessionService.start(user.id);
+
+        if (!startResult) {
+          return interaction.editReply({
+            content: "Looks like you're already clocked in. Try `/clock-out`.",
+            components: [],
+          });
+        }
+
+        const started = time(startResult.startedAt, TimestampStyles.ShortTime);
+        return interaction.editReply({
+          content: `✅ **Clocked in!**\nStarted: ${started}`,
+          components: [],
+        });
+      }
+
+      const endResult = await sessionService.end(user.id);
+      if (!endResult) {
+        return interaction.editReply({
+          content: "Looks like you're already clocked out. Try `/clock-in`.",
+          components: [],
+        });
+      }
+
+      const { session, durationMs } = endResult;
+      const started = time(session.startedAt, TimestampStyles.ShortTime);
+      const ended = time(session.endedAt, TimestampStyles.ShortTime);
+      const durationText = formatDurationMs(durationMs, { mode: "round" });
+      const activityText = session.activity ? `\nWorked on: ${session.activity}` : "";
+      return interaction.editReply({
+        content:
+          `✅ **Clocked out**\n` +
+          `Started: ${started}\n` +
+          `Ended: ${ended}\n` +
+          `Duration: ${durationText}${activityText}`,
+        components: [],
+      });
+    } catch (err) {
+      console.error("Guard button error:", err);
+      return interaction.followUp({
+        content: "Errmmm you broke something wasn't me!",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  },
+};

--- a/events/guards/handle-guard-buttons.js
+++ b/events/guards/handle-guard-buttons.js
@@ -12,13 +12,6 @@ export default {
     const { userService, sessionService } = interaction.services;
     const user = await userService.getOneDiscordId(interaction.user.id);
 
-    if (!user) {
-      return interaction.reply({
-        content: "You're not in the database yet. Use `/create-user` first.",
-        flags: MessageFlags.Ephemeral,
-      });
-    }
-
     await interaction.deferUpdate();
 
     try {

--- a/guards/requireActiveSession.js
+++ b/guards/requireActiveSession.js
@@ -7,7 +7,8 @@ export async function requireActiveSession(interaction) {
   const clockInButton = new ButtonBuilder()
     .setCustomId("guard.clock-in")
     .setLabel("Clock In")
-    .setStyle(ButtonStyle.Success);
+    .setStyle(ButtonStyle.Success)
+    .setEmoji("⏱️");
 
   const row = new ActionRowBuilder().addComponents(clockInButton);
 

--- a/guards/requireActiveSession.js
+++ b/guards/requireActiveSession.js
@@ -1,8 +1,19 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
 import { replyEphemeral } from "../utils/reply.js";
 
 export async function requireActiveSession(interaction) {
   if (interaction.context?.session) return true;
-  //TODO: Add clock in button
-  await replyEphemeral(interaction, "You're not clocked in. Use `/clock-in` first.");
+
+  const clockInButton = new ButtonBuilder()
+    .setCustomId("guard.clock-in")
+    .setLabel("Clock In")
+    .setStyle(ButtonStyle.Success);
+
+  const row = new ActionRowBuilder().addComponents(clockInButton);
+
+  await replyEphemeral(interaction, {
+    content: "You're not clocked in.",
+    components: [row],
+  });
   return false;
 }

--- a/guards/requireNoActiveSession.js
+++ b/guards/requireNoActiveSession.js
@@ -7,7 +7,8 @@ export async function requireNoActiveSession(interaction) {
   const clockOutButton = new ButtonBuilder()
     .setCustomId("guard.clock-out")
     .setLabel("Clock Out")
-    .setStyle(ButtonStyle.Danger);
+    .setStyle(ButtonStyle.Danger)
+    .setEmoji("🛑");
 
   const row = new ActionRowBuilder().addComponents(clockOutButton);
 

--- a/guards/requireNoActiveSession.js
+++ b/guards/requireNoActiveSession.js
@@ -1,8 +1,19 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
 import { replyEphemeral } from "../utils/reply.js";
 
 export async function requireNoActiveSession(interaction) {
   if (!interaction.context?.session) return true;
-  //TODO: Add clock out button
-  await replyEphemeral(interaction, "You're already clocked in. Use `/clock-out` first.");
+
+  const clockOutButton = new ButtonBuilder()
+    .setCustomId("guard.clock-out")
+    .setLabel("Clock Out")
+    .setStyle(ButtonStyle.Danger);
+
+  const row = new ActionRowBuilder().addComponents(clockOutButton);
+
+  await replyEphemeral(interaction, {
+    content: "You're already clocked in.",
+    components: [row],
+  });
   return false;
 }


### PR DESCRIPTION
- `guards/requireActiveSession.js` - now renders a “Clock in” button when no active session.
- `guards/requireNoActiveSession.js` - now renders a “Clock out” button when a session is active.
- `events/guards/handle-guard-buttons.js` - handles said button clicks
