### PR TITLE
Session: targetDuration support an readyClient fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { Client, GatewayIntentBits, Collection, Events } from "discord.js";
-//import { recoverTimersOnStartup } from "./features/sessionTimers/restoreTimers.js";
+//import { restoreTimersOnStartup } from "./features/session/restoreTimers.js";
 import addCommands from "./utils/addCommands.js";
 import addEvents from "./utils/addEvents.js";
 import { required } from "./utils/envHelpers.js";
@@ -50,7 +50,7 @@ await addEvents(client);
 
 client.once("ready", async (readyClient) => {
   console.log(`Ready! Logged in as ${readyClient.user.tag}`);
-  //await recoverTimersOnStartup(client);
+  //await restoreTimersOnStartup(client);
   addJobs(client);
 });
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import { Client, GatewayIntentBits, Collection, Events } from "discord.js";
+//import { recoverTimersOnStartup } from "./features/sessionTimers/restoreTimers.js";
 import addCommands from "./utils/addCommands.js";
 import addEvents from "./utils/addEvents.js";
 import { required } from "./utils/envHelpers.js";
@@ -47,10 +48,11 @@ console.log("Loading bot components...");
 await addCommands(client);
 await addEvents(client);
 
-// Log in bot
-await client.login(TOKEN);
-
-client.once("ready", (readyClient) => {
+client.once("ready", async (readyClient) => {
   console.log(`Ready! Logged in as ${readyClient.user.tag}`);
+  //await recoverTimersOnStartup(client);
   addJobs(client);
 });
+
+// Log in bot
+await client.login(TOKEN);

--- a/services/SessionService.js
+++ b/services/SessionService.js
@@ -6,13 +6,6 @@ export default class SessionService {
     this.User = db.User;
   }
 
-  /**
-   * Get user's active session by userId.
-   * @param {string} userId - Internal user UUID
-   * @param {Object} [options]
-   * @param {boolean} [options.includeUser=false] - Include user details in response
-   * @returns {Promise<Object|null>} Active session or null if none exists
-   */
   getOneActive(userId, { includeUser = false } = {}) {
     const options = { where: { userId, endedAt: null } };
 
@@ -28,11 +21,6 @@ export default class SessionService {
     return this.Session.findOne(options);
   }
 
-  /**
-   * Get user's active session by Discord ID.
-   * @param {string} discordId - Discord snowflake ID
-   * @returns {Promise<Object|null>} Active session with user data, or null if none exists
-   */
   async getOneActiveByDiscordId(discordId) {
     return this.Session.findOne({
       where: { endedAt: null },
@@ -48,13 +36,6 @@ export default class SessionService {
     });
   }
 
-  /**
-   * Get session by session ID.
-   * @param {string} sessionId - Session UUID
-   * @param {Object} [options]
-   * @param {boolean} [options.includeUser=false] - Include user details in response
-   * @returns {Promise<Object|null>} Session or null if not found
-   */
   getById(sessionId, { includeUser = false } = {}) {
     const options = { where: { id: sessionId } };
 
@@ -70,10 +51,6 @@ export default class SessionService {
     return this.Session.findOne(options);
   }
 
-  /**
-   * List all active sessions
-   * @returns {Promise<Array>} Array of active sessions with user info
-   */
   getAllActive() {
     return this.Session.findAll({
       where: { endedAt: null },
@@ -89,20 +66,16 @@ export default class SessionService {
     });
   }
 
-  /**
-   * Start a new session (punch-in).
-   * @param {string} userId - Internal user UUID
-   * @param {Object} [options]
-   * @param {string|null} [options.activity] - Initial activity/status text
-   * @param {Date} [options.startedAt] - Session start time (defaults to now)
-   * @returns {Promise<Object|null>} Created session, or null if user already has active session
-   */
-  async start(userId, { activity = null, startedAt = new Date() } = {}) {
+  async start(
+    userId,
+    { activity = null, startedAt = new Date(), targetDurationMinutes = 120 } = {},
+  ) {
     try {
       return await this.Session.create({
         userId,
         activity: this.#normalizeActivity(activity),
         startedAt,
+        targetDurationMinutes,
       });
     } catch (err) {
       if (err instanceof UniqueConstraintError) return null;
@@ -110,14 +83,6 @@ export default class SessionService {
     }
   }
 
-  /**
-   * End user's active session (punch-out).
-   * @param {string} userId - Internal user UUID
-   * @param {Object} [options]
-   * @param {Date} [options.endedAt] - Session end time (defaults to now)
-   * @param {boolean} [options.autoEnded=false] - Whether session was auto-closed by system
-   * @returns {Promise<{session: Object, durationMs: number}|null>} Session data with duration, or null if no active session
-   */
   async end(userId, { endedAt = new Date(), autoEnded = false } = {}) {
     const [count, rows] = await this.Session.update(
       { endedAt, autoEnded },
@@ -130,12 +95,6 @@ export default class SessionService {
     return { session, durationMs };
   }
 
-  /**
-   * Update/set active session's activity/status text.
-   * @param {string} userId - Internal user UUID
-   * @param {string|null} activity - Activity text
-   * @returns {Promise<Object|null>} Updated session or null if no active session
-   */
   async updateActivity(userId, activity) {
     const [count, rows] = await this.Session.update(
       { activity: this.#normalizeActivity(activity) },
@@ -145,12 +104,6 @@ export default class SessionService {
     return count ? rows[0] : null;
   }
 
-  /**
-   * Set target duration for active session.
-   * @param {string} userId - Internal user UUID
-   * @param {number|null} minutes - Target duration in minutes (1-480), or null to clear
-   * @returns {Promise<{session: Object, targetEndsAt: Date|null}|null>} Session with calculated end time, or null if no active session
-   */
   async setTargetDuration(userId, minutes) {
     const [count, rows] = await this.Session.update(
       { targetDurationMinutes: minutes },


### PR DESCRIPTION
1. **SessionService** : Added `targetDurationMinutes` parameter to `start()` method. Removed jsdocs
2. **Initialization order fix**: Moved `client.login()` to after ready event handler setup to prevent race conditions _(will uncomment lines for new files in the main implementation PR)_
 