### PR TITLE
fix: clock out timer cancel

### DIFF
--- a/events/interaction/handlers/button.js
+++ b/events/interaction/handlers/button.js
@@ -25,7 +25,7 @@ export const buttonHandlers = {
   },
   clock_out_button: {
     run: handleClockOutButton,
-    context: { needsUser: true, needsSession: false },
+    context: { needsUser: true, needsSession: true },
   },
   clock_in: {
     run: handleClockingInButtons,

--- a/features/liveDashboard/dashboardUI.js
+++ b/features/liveDashboard/dashboardUI.js
@@ -1,4 +1,5 @@
 import {
+  ButtonStyle,
   ContainerBuilder,
   SeparatorSpacingSize,
   MessageFlags,
@@ -22,7 +23,10 @@ export function buildLiveDashboardUI({ activeSessions = [], workedToday = [] } =
     section
       .addTextDisplayComponents((text) => text.setContent(buildHeaderText(now)))
       .setButtonAccessory((btn) =>
-        btn.setCustomId("dashboard:clock_toggle").setLabel("Clock In / Out").setStyle(3),
+        btn
+          .setCustomId("dashboard:clock_toggle")
+          .setLabel("⏱ Clock In / Out")
+          .setStyle(ButtonStyle.Primary),
       ),
   );
   container.addSeparatorComponents((sep) =>


### PR DESCRIPTION
- Fixed clock_out_button not cancelling the active session timer on manual clock-out, which could cause a ghost warning DM to be sent after the user had already clocked out
- Changed live dashboard clock toggle button style and label for clarity  _(From green to discords primary(purple))_