### PR TITLE
docs: rewrite README to reflect current bot features and architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,24 +66,28 @@ Copy the example file and fill in the values before starting the bot:
 cp ".env .example" .env
 ```
 
-| Variable                  | Required | Description                                                           | Example              |
-| ------------------------- | -------- | --------------------------------------------------------------------- | -------------------- |
-| `NODE_ENV`                | No       | Set to `production` to skip DB sync on startup                        | `development`        |
-| `token`                   | Yes      | Discord bot token                                                     | `MTIz...`            |
-| `clientId`                | Yes      | Discord application client ID (used by `deploy-commands.js`)          | `123456789012345678` |
-| `guildId`                 | Yes      | Target guild (server) ID                                              | `987654321098765432` |
-| `statusChannelId`         | No       | Channel where the good morning cron job posts                         | `111222333444555666` |
-| `HOST`                    | Yes      | PostgreSQL host                                                       | `localhost`          |
-| `DATABASE_NAME`           | Yes      | PostgreSQL database name                                              | `juno_time_dev`      |
-| `ADMIN_USERNAME`          | Yes      | PostgreSQL username                                                   | `admin`              |
-| `ADMIN_PASSWORD`          | Yes      | PostgreSQL password                                                   | `secret`             |
-| `DIALECT`                 | Yes      | Sequelize dialect (must be `postgres`)                                | `postgres`           |
-| `DEFAULT_SESSION_MINUTES` | No       | Default session target duration in minutes (default: `120`)           | `120`                |
-| `MIN_SESSION_MINUTES`     | No       | Minimum session length in minutes (default: `10`)                     | `10`                 |
-| `MAX_SESSION_MINUTES`     | No       | Hard cap on session duration in minutes (default: `480`)              | `480`                |
-| `WARN_BEFORE_MINUTES`     | No       | Minutes before session end when the warning DM is sent (default: `5`) | `5`                  |
-| `GRACE_PERIOD_MINUTES`    | No       | Extra minutes after the target before auto-end fires (default: `3`)   | `3`                  |
-| `IDLE_REFRESH_MINUTES`    | No       | Dashboard idle-refresh interval in minutes (default: `5`)             | `5`                  |
+| Variable                   | Required | Description                                                           | Example               |
+| -------------------------- | -------- | --------------------------------------------------------------------- | --------------------- |
+| `NODE_ENV`                 | No       | Set to `production` to skip DB sync on startup                        | `development`         |
+| `token`                    | Yes      | Discord bot token                                                     | `MTIz...`             |
+| `clientId`                 | Yes      | Discord application client ID (used by `deploy-commands.js`)          | `123456789012345678`  |
+| `guildId`                  | Yes      | Target guild (server) ID                                              | `987654321098765432`  |
+| `statusChannelId`          | No       | Channel where the good morning cron job posts                         | `111222333444555666`  |
+| `HOST`                     | Yes      | PostgreSQL host                                                       | `localhost`           |
+| `DATABASE_NAME`            | Yes      | PostgreSQL database name                                              | `juno_time_dev`       |
+| `ADMIN_USERNAME`           | Yes      | PostgreSQL username                                                   | `admin`               |
+| `ADMIN_PASSWORD`           | Yes      | PostgreSQL password                                                   | `secret`              |
+| `DIALECT`                  | Yes      | Sequelize dialect (must be `postgres`)                                | `postgres`            |
+| `DEFAULT_SESSION_MINUTES`  | No       | Default session target duration in minutes (default: `120`)           | `120`                 |
+| `MIN_SESSION_MINUTES`      | No       | Minimum session length in minutes (default: `10`)                     | `10`                  |
+| `MAX_SESSION_MINUTES`      | No       | Hard cap on session duration in minutes (default: `480`)              | `480`                 |
+| `WARN_BEFORE_MINUTES`      | No       | Minutes before session end when the warning DM is sent (default: `5`) | `5`                   |
+| `GRACE_PERIOD_MINUTES`     | No       | Extra minutes after the target before auto-end fires (default: `3`)   | `3`                   |
+| `IDLE_REFRESH_MINUTES`     | No       | Dashboard idle-refresh interval in minutes (default: `5`)             | `5`                   |
+| `HEALTH_POLL_SCHEDULE`     | No       | Cron expression for automated health checks (default: `*/5 * * * *`)  | `*/1 * * * *`         |
+| `BOT_ISSUES_CHANNEL_ID`    | No       | Channel where health alerts are posted; alerts are silenced if unset  | `111222333444555666`  |
+| `ADMIN_USER_IDS`           | No       | Comma-separated Discord user IDs to ping on persistent failures       | `123456789,987654321` |
+| `HEALTH_FAILURE_THRESHOLD` | No       | Consecutive failures before admins are pinged (default: `3`)          | `3`                   |
 
 ---
 
@@ -127,6 +131,7 @@ node deploy-commands.js
 | `/projects-links`  | Manage links attached to your projects                                                                          |
 | `/create-user`     | Register your Discord account in the database (required before using other commands)                            |
 | `/setup-dashboard` | Initialize the live dashboard in the current channel (admin setup, run once per channel)                        |
+| `/health`          | Check bot and database health: Discord gateway status, DB latency, and process uptime. Admin only.              |
 
 ---
 
@@ -148,6 +153,20 @@ The single `InteractionCreate` handler dispatches by type:
 - **Modal submit** → same prefix approach
 - **Select menu** → same prefix approach
 
+For buttons, modals, and select menus the routing key is everything before the first `:` in `customId`. A button built with `.setCustomId("timer:pause:abc-123")` matches the `timer` entry in `buttonHandlers`. The rest of the `customId` after the first `:` can carry whatever payload the handler needs.
+
+Handlers are registered in `events/interaction/handlers/button.js` (and the equivalent `modal.js` / `select.js`) as:
+
+```js
+// events/interaction/handlers/button.js
+export const buttonHandlers = {
+  timer: {
+    run: handleTimerButtons,          // function that receives the interaction
+    context: { needsUser: true, needsSession: false }, // which DB lookups to run first
+  },
+};
+```
+
 ### Services pattern
 
 All database access goes through service classes in `services/`. Commands and handlers access them via `interaction.services`, never by importing models directly.
@@ -160,6 +179,7 @@ All database access goes through service classes in `services/`. Commands and ha
 | `projectService`   | Project CRUD; member management; archive/restore                         |
 | `linkService`      | Create, update, and delete links attached to projects                    |
 | `dashboardService` | Persist and retrieve live dashboard channel/message state                |
+| `healthService`    | Check Discord gateway and database connectivity; drives the health poll  |
 
 ### Guards
 
@@ -172,10 +192,13 @@ Commands declare a `guards` array. Before `execute` is called, each guard return
 
 ### Feature modules - `features/`
 
-- `liveDashboard/` - dashboard rendering, throttled updater, idle refresh, startup initialisation
-- `session/` - timer lifecycle (warn → grace → auto-end), timer restoration, clock-in/out UI builders, personal dashboard UI
-- `tasks/` - task dashboard embed builder
-- `projects/links/` - link manager UI renderer
+Complex logic and UI that would make command files too large is split into focused subfolders here.
+
+- `liveDashboard/` - builds and updates the persistent dashboard message in the designated channel. Handles throttling (so rapid activity does not spam Discord), the idle-refresh timer, and restoring the dashboard on bot startup.
+- `session/` - everything that happens during a work session: the countdown timer that sends a warning DM before the session ends and then auto-ends it after the grace period, restoring in-memory timers when the bot restarts, and the UI builders for the clock-in flow and personal dashboard.
+- `tasks/` - builds the embed shown in `/my-tasks`.
+- `projects/links/` - builds the UI for managing links attached to a project.
+- `health/` - runs the automated health poll on a cron schedule and posts alerts to a designated channel when checks fail or recover.
 
 ---
 
@@ -183,15 +206,18 @@ Commands declare a `guards` array. Before `execute` is called, each guard return
 
 1. Create a `.js` file in the appropriate subfolder under `commands/`.
 2. Export a default object:
+
    ```js
    export default {
      data: new SlashCommandBuilder().setName("my-command").setDescription("..."),
      guards: [], // optional
+     skipContext: false, // set to true to skip DB user lookup (interaction.botContext will not be populated)
      async execute(interaction) {
        /* ... */
      },
    };
    ```
+
 3. Run `node deploy-commands.js` to register the command with Discord.
 
 ---
@@ -206,8 +232,6 @@ pnpm lint:fix      # auto-fix
 pnpm format        # write formatting
 pnpm format:check  # check only
 ```
-
-Prettier settings: double quotes, trailing commas, 100-character print width.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# juno-bot
+# JunoBot
 
 A Discord bot for Juniors.dev that provides time-tracking, project management, task management, and a live server dashboard. Members clock in and out of work sessions, attach tasks and projects to those sessions, and see real-time activity on a shared channel dashboard.
 
@@ -6,12 +6,12 @@ A Discord bot for Juniors.dev that provides time-tracking, project management, t
 
 ## Features
 
-- **Session tracking** — clock in to start a timed work session, clock out to end it; sessions record activity text, duration, and linked tasks
-- **Session timers** — configurable warn-before and grace-period windows; the bot DMs a warning before the target duration expires and auto-ends the session after the grace period; timers survive bot restarts
-- **Live dashboard** — a persistent channel message showing who is currently clocked in and a daily leaderboard of total time worked; updates on a throttled trailing-edge schedule with a configurable idle refresh interval
-- **Personal dashboard** — `/my-dashboard` shows per-user monthly stats: total time, session count, average session length, longest session, best day, and active-day streak
-- **Task management** — create, update, archive, and delete tasks; filter by status; tasks can be linked to projects and attached to the active session at clock-in
-- **Project management** — create, edit, archive, restore, and delete projects; role-based membership with admin and link-add permissions; attach categorised links (GitHub, Figma, docs, etc.) to each project
+- **Session tracking** - clock in to start a timed work session, clock out to end it; sessions record activity text, duration, and linked tasks
+- **Session timers** - configurable warn-before and grace-period windows; the bot DMs a warning before the target duration expires and auto-ends the session after the grace period; timers survive bot restarts
+- **Live dashboard** - a persistent channel message showing who is currently clocked in and a daily leaderboard of total time worked; updates on a throttled trailing-edge schedule with a configurable idle refresh interval
+- **Personal dashboard** - `/my-dashboard` shows per-user monthly stats: total time, session count, average session length, longest session, best day, and active-day streak
+- **Task management** - create, update, archive, and delete tasks; filter by status; tasks can be linked to projects and attached to the active session at clock-in
+- **Project management** - create, edit, archive, restore, and delete projects; role-based membership with admin and link-add permissions; attach categorised links (GitHub, Figma, docs, etc.) to each project
 
 ---
 
@@ -130,14 +130,14 @@ node deploy-commands.js
 
 ## Architecture overview
 
-### Entry point — `index.js`
+### Entry point - `index.js`
 
 1. Connects to PostgreSQL via Sequelize and syncs models (development only).
 2. Attaches all service instances to every incoming interaction via a `prependListener` on `InteractionCreate`, making them available as `interaction.services`.
 3. Recursively loads commands from `commands/` and events from `events/`.
 4. On `ready`: restores in-memory timers for any sessions active before the process started, initialises the live dashboard, and registers cron jobs.
 
-### Interaction routing — `events/interaction/`
+### Interaction routing - `events/interaction/`
 
 The single `InteractionCreate` handler dispatches by type:
 
@@ -168,12 +168,12 @@ Commands declare a `guards` array. Before `execute` is called, each guard return
 | `requireActiveSession`   | Aborts if no active session is found; offers a Clock In button |
 | `requireNoActiveSession` | Aborts if an active session exists; offers a Clock Out button  |
 
-### Feature modules — `features/`
+### Feature modules - `features/`
 
-- `liveDashboard/` — dashboard rendering, throttled updater, idle refresh, startup initialisation
-- `session/` — timer lifecycle (warn → grace → auto-end), timer restoration, clock-in/out UI builders, personal dashboard UI
-- `tasks/` — task dashboard embed builder
-- `projects/links/` — link manager UI renderer
+- `liveDashboard/` - dashboard rendering, throttled updater, idle refresh, startup initialisation
+- `session/` - timer lifecycle (warn → grace → auto-end), timer restoration, clock-in/out UI builders, personal dashboard UI
+- `tasks/` - task dashboard embed builder
+- `projects/links/` - link manager UI renderer
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -192,8 +192,6 @@ Commands declare a `guards` array. Before `execute` is called, each guard return
 
 ### Feature modules - `features/`
 
-Complex logic and UI that would make command files too large is split into focused subfolders here.
-
 - `liveDashboard/` - builds and updates the persistent dashboard message in the designated channel. Handles throttling (so rapid activity does not spam Discord), the idle-refresh timer, and restoring the dashboard on bot startup.
 - `session/` - everything that happens during a work session: the countdown timer that sends a warning DM before the session ends and then auto-ends it after the grace period, restoring in-memory timers when the bot restarts, and the UI builders for the clock-in flow and personal dashboard.
 - `tasks/` - builds the embed shown in `/my-tasks`.

--- a/README.md
+++ b/README.md
@@ -1,92 +1,213 @@
 # juno-bot
 
-An organizational bot for our discord.
+A Discord bot for Juniors.dev that provides time-tracking, project management, task management, and a live server dashboard. Members clock in and out of work sessions, attach tasks and projects to those sessions, and see real-time activity on a shared channel dashboard.
 
-# Juno-bot
-
-A Discord bot for Juniors.dev that summarizes chat activity using AI (TinyLlama via Ollama on Fly.io), manages daily status, and more.
+---
 
 ## Features
 
-- **AI Summarization**: Summarizes large amounts of chat using chunked requests to an Ollama AI server.
-- **Daily Scheduler**: Posts good morning and good night messages automatically.
-- **Slash Commands**: Includes `/summarize-channel`, `/status`, `/note`, `/todo`, and more.
+- **Session tracking** — clock in to start a timed work session, clock out to end it; sessions record activity text, duration, and linked tasks
+- **Session timers** — configurable warn-before and grace-period windows; the bot DMs a warning before the target duration expires and auto-ends the session after the grace period; timers survive bot restarts
+- **Live dashboard** — a persistent channel message showing who is currently clocked in and a daily leaderboard of total time worked; updates on a throttled trailing-edge schedule with a configurable idle refresh interval
+- **Personal dashboard** — `/my-dashboard` shows per-user monthly stats: total time, session count, average session length, longest session, best day, and active-day streak
+- **Task management** — create, update, archive, and delete tasks; filter by status; tasks can be linked to projects and attached to the active session at clock-in
+- **Project management** — create, edit, archive, restore, and delete projects; role-based membership with admin and link-add permissions; attach categorised links (GitHub, Figma, docs, etc.) to each project
 
-## Setup
+---
 
-### 1. Clone the repository
+## Prerequisites
 
-```sh
-git clone https://github.com/johnDavid97/Juno-bot.git
-cd Juno-bot
-```
+- Node.js 22 or later
+- pnpm
+- Docker and Docker Compose (for the local PostgreSQL database)
+- A Discord application with a bot token and a target guild
 
-### 2. Install dependencies
+---
 
-```sh
-npm install
-```
-
-### 3. Configure the bot
-
-Edit `config.json` with your Discord bot credentials and channel IDs:
-
-```json
-{
-  "token": "YOUR_DISCORD_BOT_TOKEN",
-  "statusChannelId": "DISCORD_CHANNEL_ID_FOR_STATUS",
-  "chatSummaryChannelId": "DISCORD_CHANNEL_ID_FOR_SUMMARIES",
-  "clientId": "YOUR_BOT_CLIENT_ID",
-  "guildId": "YOUR_GUILD_ID",
-  "sourceChannelIds": ["CHANNEL_ID_1", "CHANNEL_ID_2"],
-  "ollamaUrl": "https://your-ollama-instance.fly.dev",
-  "ollamaModel": "tinyllama"
-}
-```
-
-**Never commit your real token to version control!**
-
-### 4. Enable Message Content Intent
-
-- In the [Discord Developer Portal](https://discord.com/developers/applications), go to your bot's settings.
-- Under "Privileged Gateway Intents", enable **Message Content Intent**.
-- Make sure your bot code includes `GatewayIntentBits.MessageContent` (already set in `index.js`).
-
-### 5. Run the bot
+## Installation
 
 ```sh
-node index.js
+git clone https://github.com/Juniors-Dev/juno-bot.git
+cd juno-bot
+pnpm install
 ```
 
-## Deploying Slash Commands
+---
 
-Whenever you add or modify slash commands in the `commands/` directory, you need to deploy them to Discord:
+## Database setup
+
+Start a local PostgreSQL 15 instance using the provided compose file:
 
 ```sh
-node deploy-commands.js.js
+docker-compose up -d
 ```
 
-This will register (or update) all slash commands for your guild.
+This creates a container named `pg_juno_dev` on port `5432` with the following defaults:
 
-## Usage
+| Setting       | Default value   |
+| ------------- | --------------- |
+| User          | `admin`         |
+| Password      | `secret`        |
+| Database name | `juno_time_dev` |
 
-- Use `/summarize-channel` to summarize a channel's recent messages. The bot will handle large histories by chunking and combining summaries.
-- Other commands: `/status`, `/note`, `/todo`, etc.
+Data is persisted in a Docker volume named `pg_data`.
 
-## Troubleshooting
+In development mode the bot runs `sequelize.sync({ alter: true })` on startup, so tables are created and migrated automatically. In production (`NODE_ENV=production`) the sync step is skipped.
 
-- **Bot can't read messages?**  
-  Ensure the "Message Content Intent" is enabled in both the Discord Developer Portal and your code.
-- **Summarization times out or fails?**  
-  This can happen if the Ollama server is cold-starting or overloaded. Try again, or adjust your Fly.io auto-stop settings to reduce cold starts.
-- **Token/context limits?**  
-  The bot automatically chunks large message histories to fit within AI model limits.
+---
 
-## Development
+## Environment variables
 
-- Commands are in `commands/`
-- AI logic is in `utils/aiSummary.js`
-- Scheduled tasks and main logic are in `index.js`
+Copy the example file and fill in the values before starting the bot:
+
+```sh
+cp ".env .example" .env
+```
+
+| Variable                  | Required | Description                                                           | Example              |
+| ------------------------- | -------- | --------------------------------------------------------------------- | -------------------- |
+| `NODE_ENV`                | No       | Set to `production` to skip DB sync on startup                        | `development`        |
+| `token`                   | Yes      | Discord bot token                                                     | `MTIz...`            |
+| `clientId`                | Yes      | Discord application client ID (used by `deploy-commands.js`)          | `123456789012345678` |
+| `guildId`                 | Yes      | Target guild (server) ID                                              | `987654321098765432` |
+| `statusChannelId`         | No       | Channel where the good morning cron job posts                         | `111222333444555666` |
+| `HOST`                    | Yes      | PostgreSQL host                                                       | `localhost`          |
+| `DATABASE_NAME`           | Yes      | PostgreSQL database name                                              | `juno_time_dev`      |
+| `ADMIN_USERNAME`          | Yes      | PostgreSQL username                                                   | `admin`              |
+| `ADMIN_PASSWORD`          | Yes      | PostgreSQL password                                                   | `secret`             |
+| `DIALECT`                 | Yes      | Sequelize dialect (must be `postgres`)                                | `postgres`           |
+| `DEFAULT_SESSION_MINUTES` | No       | Default session target duration in minutes (default: `120`)           | `120`                |
+| `MIN_SESSION_MINUTES`     | No       | Minimum session length in minutes (default: `10`)                     | `10`                 |
+| `MAX_SESSION_MINUTES`     | No       | Hard cap on session duration in minutes (default: `480`)              | `480`                |
+| `WARN_BEFORE_MINUTES`     | No       | Minutes before session end when the warning DM is sent (default: `5`) | `5`                  |
+| `GRACE_PERIOD_MINUTES`    | No       | Extra minutes after the target before auto-end fires (default: `3`)   | `3`                  |
+| `IDLE_REFRESH_MINUTES`    | No       | Dashboard idle-refresh interval in minutes (default: `5`)             | `5`                  |
+
+---
+
+## Running the bot
+
+**Development** (file-watcher restarts on changes):
+
+```sh
+pnpm dev
+```
+
+**Production:**
+
+```sh
+pnpm start
+```
+
+Both scripts load `.env` automatically via the Node.js `--env-file` flag.
+
+---
+
+## Registering slash commands
+
+Slash commands must be registered with Discord before they appear in the server. Run this once after cloning, and again whenever you add or rename a command:
+
+```sh
+node deploy-commands.js
+```
+
+---
+
+## Available slash commands
+
+| Command            | Description                                                                                                     |
+| ------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `/clock-in`        | Start a new work session; shows a UI to select tasks and set an activity note                                   |
+| `/clock-out`       | End the current work session and display a session summary                                                      |
+| `/my-dashboard`    | View your monthly work statistics (total time, streaks, best day, etc.)                                         |
+| `/my-tasks`        | View and manage your tasks with an optional `filter` parameter (`active`, `todo`, `in_progress`, `done`, `all`) |
+| `/projects`        | List, create, edit, archive, restore, and delete your projects                                                  |
+| `/projects-links`  | Manage links attached to your projects                                                                          |
+| `/create-user`     | Register your Discord account in the database (required before using other commands)                            |
+| `/setup-dashboard` | Initialize the live dashboard in the current channel (admin setup, run once per channel)                        |
+
+---
+
+## Architecture overview
+
+### Entry point — `index.js`
+
+1. Connects to PostgreSQL via Sequelize and syncs models (development only).
+2. Attaches all service instances to every incoming interaction via a `prependListener` on `InteractionCreate`, making them available as `interaction.services`.
+3. Recursively loads commands from `commands/` and events from `events/`.
+4. On `ready`: restores in-memory timers for any sessions active before the process started, initialises the live dashboard, and registers cron jobs.
+
+### Interaction routing — `events/interaction/`
+
+The single `InteractionCreate` handler dispatches by type:
+
+- **Chat input** → looks up `interaction.commandName` in `client.commands`, runs guards, then `execute`
+- **Button** → keyed by the prefix before the first `:` in `customId`
+- **Modal submit** → same prefix approach
+- **Select menu** → same prefix approach
+
+### Services pattern
+
+All database access goes through service classes in `services/`. Commands and handlers access them via `interaction.services`, never by importing models directly.
+
+| Service            | Responsibility                                                           |
+| ------------------ | ------------------------------------------------------------------------ |
+| `userService`      | User CRUD by Discord ID or internal UUID                                 |
+| `sessionService`   | Start, end, update, and query work sessions; monthly stats; daily totals |
+| `taskService`      | Task CRUD; link tasks to sessions; status filtering                      |
+| `projectService`   | Project CRUD; member management; archive/restore                         |
+| `linkService`      | Create, update, and delete links attached to projects                    |
+| `dashboardService` | Persist and retrieve live dashboard channel/message state                |
+
+### Guards
+
+Commands declare a `guards` array. Before `execute` is called, each guard returns `true` to allow or `false` (after sending an ephemeral reply) to abort.
+
+| Guard                    | Behaviour                                                      |
+| ------------------------ | -------------------------------------------------------------- |
+| `requireActiveSession`   | Aborts if no active session is found; offers a Clock In button |
+| `requireNoActiveSession` | Aborts if an active session exists; offers a Clock Out button  |
+
+### Feature modules — `features/`
+
+- `liveDashboard/` — dashboard rendering, throttled updater, idle refresh, startup initialisation
+- `session/` — timer lifecycle (warn → grace → auto-end), timer restoration, clock-in/out UI builders, personal dashboard UI
+- `tasks/` — task dashboard embed builder
+- `projects/links/` — link manager UI renderer
+
+---
+
+## Adding a new slash command
+
+1. Create a `.js` file in the appropriate subfolder under `commands/`.
+2. Export a default object:
+   ```js
+   export default {
+     data: new SlashCommandBuilder().setName("my-command").setDescription("..."),
+     guards: [], // optional
+     async execute(interaction) {
+       /* ... */
+     },
+   };
+   ```
+3. Run `node deploy-commands.js` to register the command with Discord.
+
+---
+
+## Code style
+
+The project uses ESLint and Prettier. A Husky pre-commit hook runs both checks automatically.
+
+```sh
+pnpm lint          # check only
+pnpm lint:fix      # auto-fix
+pnpm format        # write formatting
+pnpm format:check  # check only
+```
+
+Prettier settings: double quotes, trailing commas, 100-character print width.
+
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,7 @@ Start a local PostgreSQL 15 instance using the provided compose file:
 docker-compose up -d
 ```
 
-This creates a container named `pg_juno_dev` on port `5432` with the following defaults:
-
-| Setting       | Default value   |
-| ------------- | --------------- |
-| User          | `admin`         |
-| Password      | `secret`        |
-| Database name | `juno_time_dev` |
-
-Data is persisted in a Docker volume named `pg_data`.
+This creates a container named `pg_juno_dev` on port `5432`. Data is persisted in a Docker volume named `pg_data`.
 
 In development mode the bot runs `sequelize.sync({ alter: true })` on startup, so tables are created and migrated automatically. In production (`NODE_ENV=production`) the sync step is skipped.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Personal dashboard** - `/my-dashboard` shows per-user monthly stats: total time, session count, average session length, longest session, best day, and active-day streak
 - **Task management** - create, update, archive, and delete tasks; filter by status; tasks can be linked to projects and attached to the active session at clock-in
 - **Project management** - create, edit, archive, restore, and delete projects; role-based membership with admin and link-add permissions; attach categorised links (GitHub, Figma, docs, etc.) to each project
+- **Health monitoring** - an admin-only cron job polls the bot and database on a configurable schedule; results are posted to a designated channel with alerts on failure and a recovery notice when service is restored; persistent failures trigger a ping to configured admin users; an on-demand `/health` command shows Discord gateway status, database latency, and process uptime
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# JunoBot
-
-A Discord bot for Juniors.dev that provides time-tracking, project management, task management, and a live server dashboard. Members clock in and out of work sessions, attach tasks and projects to those sessions, and see real-time activity on a shared channel dashboard.
+<div align="center">
+  <img src="https://github.com/user-attachments/assets/4ad1172f-af27-41cf-8cb9-7079253ff5bc" width="120" alt="juno-bot" />
+  <h1>JunoBot</h1>
+  <p>A Discord bot for Juniors.dev that provides time-tracking, project management, task management, and a live server dashboard.</p>
+</div>
 
 ---
 


### PR DESCRIPTION
- Replaces the outdated README that still described the old AI summarization bot
- Covers features, setup, environment variables, slash commands, architecture overview, and the services/guards pattern
- Includes changes that are still waiting review (health check system and pnpm change), consider reviewing those PRs first.

❔ Unsure about including **Health monitoring** in the main features section at the top or not ❔

Ps. I've not included the dad-joke thing as of now, but feel free to add or change if anything's missing or incorrect:)